### PR TITLE
Add attribute for auto-accepting Chef license

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -44,7 +44,7 @@ end
 group :graylog2 do
   cookbook 'authbind'
   cookbook 'elasticsearch', '= 0.3.14'
-  cookbook 'graylog2'
+  cookbook 'graylog2', '< 2.0'
   cookbook 'java'
   cookbook 'mongodb', git: 'git@github.com:chef-brigade/mongodb-cookbook.git'
 end

--- a/roles/chef-server.json
+++ b/roles/chef-server.json
@@ -4,7 +4,8 @@
   "json_class": "Chef::Role",
   "default_attributes": {
     "chef-server": {
-      "addons": ["manage"]
+      "addons": ["manage"],
+      "accept_license": true
     }
   },
   "override_attributes": {


### PR DESCRIPTION
Fix error:

>     [2016-05-16T05:28:29+00:00] ERROR: Exception handlers complete
>        Chef Client failed. 76 resources updated in 01 hours 48 minutes 22 seconds
>        [2016-05-16T05:28:29+00:00] FATAL: Stacktrace dumped to /tmp/kitchen/cache/chef-stacktrace.out
>        [2016-05-16T05:28:29+00:00] FATAL: Please provide the contents of the stacktrace.out file if you file a bug report
>        [2016-05-16T05:28:29+00:00] ERROR: chef_ingredient[manage] (chef-server::addons line 20) had an error: Mixlib::ShellOut::ShellCommandFailed: execute[chef-manage-reconfigure] (/tmp/kitchen/cache/cookbooks/chef-ingredient/libraries/chef_ingredient_provider.rb line 105) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '1'
>        ---- Begin output of chef-manage-ctl reconfigure ----
>        STDOUT: To use this software, you must agree to the terms of the software license agreement.
>        Please view and accept the software license agreement, or pass --accept-license.
>        STDERR: 
>        ---- End output of chef-manage-ctl reconfigure ----
>        Ran chef-manage-ctl reconfigure returned 1
>        [2016-05-16T05:28:30+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)