### PR TITLE
#7 Update graylog and ES

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -43,8 +43,8 @@ end
 
 group :graylog2 do
   cookbook 'authbind'
-  cookbook 'elasticsearch', '= 0.3.14'
-  cookbook 'graylog2', '< 2.0'
+  cookbook 'elasticsearch', '~> 2'
+  cookbook 'graylog2'
   cookbook 'java'
   cookbook 'mongodb', git: 'git@github.com:chef-brigade/mongodb-cookbook.git'
 end

--- a/roles/graylog-server.json
+++ b/roles/graylog-server.json
@@ -4,8 +4,7 @@
   "json_class": "Chef::Role",
   "default_attributes": {
     "elasticsearch": {
-      "version": "2.3.5",
-      "allocated_memory": "512m"
+      "version": "2.3.5"
     },
     "graylog2": {
       "password_secret": "NP8GePxntdVuQ5L3rK80fOR9mVU0gmopqMpmZdR58m7IZVo9hL4nIgGdG1L1Zh3O6jM0Delnso8EibLdhZ3F2lLXeklHdeib",

--- a/roles/graylog-server.json
+++ b/roles/graylog-server.json
@@ -4,25 +4,21 @@
   "json_class": "Chef::Role",
   "default_attributes": {
     "elasticsearch": {
-      "cluster": {
-        "name": "graylog2"
-      },
-      "version": "1.5.2",
+      "version": "2.3.5",
       "allocated_memory": "512m"
     },
     "graylog2": {
       "password_secret": "NP8GePxntdVuQ5L3rK80fOR9mVU0gmopqMpmZdR58m7IZVo9hL4nIgGdG1L1Zh3O6jM0Delnso8EibLdhZ3F2lLXeklHdeib",
+      "root_timezone": "UTC",
+      "root_password_sha2": "8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918",
       "rest": {
         "admin_access_token": "NlXQ1B375BQPdocO1hzoVTKowWjAsgGzIoHfm3zMR0lHU24341XszauM52L5EZu0shR6CMJtM9cwdpxKMhGGDoybtcRtiQif"
       },
-      "root_password_sha2": "8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918",
       "server": {
         "java_opts": "-Djava.net.preferIPv4Stack=true -Xms512m -Xmx512m -XX:NewRatio=1 -XX:PermSize=128m -XX:MaxPermSize=256m -server -XX:+ResizeTLAB -XX:+UseConcMarkSweepGC -XX:+CMSConcurrentMTEnabled -XX:+CMSClassUnloadingEnabled -XX:+UseParNewGC -XX:-OmitStackTraceInFastThrow"
       },
-      "web": {
-        "secret": "NP8GePxntdVuQ5L3rK80fOR9mVU0gmopqMpmZdR58m7IZVo9hL4nIgGdG1L1Zh3O6jM0Delnso8EibLdhZ3F2lLXeklHdeib",
-        "timezone": "UTC",
-        "java_opts": "-Djava.net.preferIPv4Stack=true -Xms512m -Xmx512m"
+      "elasticsearch": {
+        "cluster_name": "elasticsearch"
       }
     },
     "java": {
@@ -43,7 +39,6 @@
     "recipe[mongodb]",
     "recipe[graylog2]",
     "recipe[graylog2::server]",
-    "recipe[graylog2::web]",
     "recipe[graylog2::authbind]",
     "recipe[zabbix_templates::graylog]"
   ],


### PR DESCRIPTION
* Update graylog version.
* Remove graylog2:web, because recipe has been removed (https://github.com/Graylog2/graylog2-cookbook/issues/57).
* Update elasticsearch.
* Remove cluster attributes for ES because they have been moved to resource.