### PR TITLE
Add jdk_version attribute in kitchen.yml

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -41,6 +41,9 @@ suites:
       - role[base]
       - role[zabbix-server]
   - name: all
+    attributes:
+      java:
+        jdk_version: "8"
     run_list:
       - recipe[apt]
       - recipe[bsw_gpg]


### PR DESCRIPTION
Cookbook java по умолчанию пытается поставить openjdk 6. Его нет в репозиториях Ubuntu 16.04. Сделал установку 8 версии.